### PR TITLE
Fix backward compatibility issue

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
     },
     "require": {
         "php": ">=5.3.0",
-        "kriswallsmith/buzz": ">=v0.10",
+        "kriswallsmith/buzz": ">=v0.10 <=0.16.1",
         "psr/log": "~1.0"
     },
     "require-dev": {


### PR DESCRIPTION
Class Buzz\Message\Request no longer exists since kriswallsmith/buzz - v0.17.0