### PR TITLE
Small auth fix

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "admitad/api",
+    "name": "meniam/admitad-php-api",
     "type": "library",
     "description": "Admitad api library",
     "keywords": ["admitad", "api"],

--- a/src/Admitad/Api/Api.php
+++ b/src/Admitad/Api/Api.php
@@ -35,7 +35,7 @@ class Api
     {
         $query = array(
             'client_id' => $clientId,
-            'grant_type' => 'password',
+            'grant_type' => 'client_credentials',
             'username' => $username,
             'password' => $password,
             'scope' => $scope


### PR DESCRIPTION
The value 'password' of key 'grant_type' in function authorizeByPassword of in /src/Admitad/Api/Api.php doesn't work anymore, instead 'client_credentials' value works.