### PR TITLE
Remove package psr/log~1.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,8 +9,7 @@
     },
     "require": {
         "php": ">=7.1",
-        "kriswallsmith/buzz": ">=v0.10 <=0.16.1",
-        "psr/log": "~1.0"
+        "kriswallsmith/buzz": ">=v0.10 <=0.16.1"
     },
     "require-dev": {
         "phpunit/phpunit": "3.7.*"


### PR DESCRIPTION
Should remove psr/log~1.0 because it doesn't use and problems when install it on some project wich uses psr/log^3.0
![image](https://user-images.githubusercontent.com/22128719/224493071-cae7a352-5d8a-4dc5-a361-bfefe28005aa.png)
